### PR TITLE
Added callback hook to retrieve data in real time

### DIFF
--- a/rktellolib/Tello.py
+++ b/rktellolib/Tello.py
@@ -1,6 +1,7 @@
 from rktellolib.TelloCommand import TelloCommand
 from rktellolib.TelloState import TelloState
 from rktellolib.TelloCam import TelloCam
+from typing import Callable
 
 """
 Class Description:
@@ -29,12 +30,13 @@ class Tello():
 
   """
   Constructor that instantiates the needed objects
+  Argument: state_callback - A Callable that will receive the drone state on a separate thread 
   """
-  def __init__(self, debug: bool=False, has_video: bool=False):
+  def __init__(self, debug: bool=False, has_video: bool=False, state_callback: Callable[[str],None]=None):
     self.__has_video = has_video
 
     self.__command = TelloCommand(debug)
-    self.__state = TelloState(debug)
+    self.__state = TelloState(debug, state_callback)
 
     if has_video:
       self.__cam = TelloCam()

--- a/rktellolib/TelloState.py
+++ b/rktellolib/TelloState.py
@@ -1,6 +1,7 @@
 import time
 import socket
 from threading import Thread
+from typing import Callable
 
 """
 Class Description:
@@ -25,7 +26,7 @@ class TelloState:
   """
   Constructor that creates the thread to receive responses
   """
-  def __init__(self, debug: bool=True):
+  def __init__(self, debug: bool=True, callback: Callable[[str],None]=None):
     self.__debug = debug
 
     # Open local UDP port for Tello communication
@@ -35,6 +36,9 @@ class TelloState:
 
     # Bind the thread to receive responses from the drone
     self.__thread = Thread(target=self.__thread_function, daemon=True)
+
+    # Set callback to send most recent state from the drone
+    self.__callback = callback
 
   """
   Destructor that only closes the socket when the object is deleted because sockets are not thread safe
@@ -54,6 +58,8 @@ class TelloState:
         if self.__debug:
           print('[TelloState]: {}'.format(state))
         self.__current_state = state.decode("utf-8").rstrip("\r\n")
+        if self.__callback:
+          self.__callback(self.__current_state)
       except (UnicodeDecodeError, socket.error) as err:
         print('[TelloState] Error: {}'.format(err))
 


### PR DESCRIPTION
Instead of querying for drone states at arbitrary times through `drone.get_states()`, users can now pass in a callback function on Tello instantiation `drone = Tello(state_callback=my_callback)`. The TelloState class will call the `my_callback` function the moment after state data is received from the Tello socket. The my_callback function should have a function signature `Callable[[str], None]`